### PR TITLE
Support CentOS 7

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -24,7 +24,8 @@ platforms:
   - name: freebsd-9.2
     run_list:
     - recipe[freebsd::portsnap]
-  - name: centos-6.5
+  - name: centos-7.0
+  - name: centos-6.6
   - name: centos-5.10
 
 suites:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -38,4 +38,6 @@ suites:
    attributes:
      nrpe:
        install_method: 'source'
-
+ - name: check
+   run_list:
+   - recipe[chef_nrpe_test::default]

--- a/Berksfile
+++ b/Berksfile
@@ -6,3 +6,5 @@ group :integration do
   cookbook 'freebsd'
   cookbook 'chef-solo-search'
 end
+
+cookbook 'chef_nrpe_test', path: 'test/fixtures/cookbooks/chef_nrpe_test'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -59,6 +59,11 @@ Vagrant::Config.run do |config|
     nagios.vm.host_name = 'nrpe-65'
   end
 
+  config.vm.define :nrpe_centos_70 do |nagios|
+    nagios.vm.box = 'chef/centos-7.0'
+    nagios.vm.host_name = 'nrpe-70'
+  end
+
   config.vm.define :nrpe_fedora_20 do |nagios|
     nagios.vm.box = 'chef/fedora-20'
     nagios.vm.host_name = 'nrpe-fedora-20'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -70,7 +70,6 @@ when 'debian'
   default['nrpe']['packages']          = %w(nagios-nrpe-server nagios-plugins nagios-plugins-basic nagios-plugins-standard)
   default['nrpe']['plugin_dir']        = '/usr/lib/nagios/plugins'
   default['nrpe']['conf_dir']          = '/etc/nagios'
-  default['nrpe']['check_action']      = 'reload'
   if node['kernel']['machine'] == 'i686'
     default['nrpe']['ssl_lib_dir']     = '/usr/lib/i386-linux-gnu'
   else

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -58,6 +58,8 @@ default['nrpe']['server_role'] = 'monitoring'
 default['nrpe']['allowed_hosts'] = nil
 default['nrpe']['using_solo_search'] = false
 default['nrpe']['multi_environment_monitoring'] = false
+# this is mostly true except for centos-70
+default['nrpe']['check_action'] = 'reload'
 
 # platform specific values
 case node['platform_family']
@@ -68,6 +70,7 @@ when 'debian'
   default['nrpe']['packages']          = %w(nagios-nrpe-server nagios-plugins nagios-plugins-basic nagios-plugins-standard)
   default['nrpe']['plugin_dir']        = '/usr/lib/nagios/plugins'
   default['nrpe']['conf_dir']          = '/etc/nagios'
+  default['nrpe']['check_action']      = 'reload'
   if node['kernel']['machine'] == 'i686'
     default['nrpe']['ssl_lib_dir']     = '/usr/lib/i386-linux-gnu'
   else
@@ -79,6 +82,10 @@ when 'debian'
     default['nrpe']['service_name']    = 'nrpe'
   end
 when 'rhel', 'fedora'
+  case node['platform_version'].to_i
+  when 7
+    default['nrpe']['check_action'] = 'restart'
+  end
   default['nrpe']['install_method']    = 'package'
   default['nrpe']['pid_file']          = '/var/run/nrpe.pid'
   default['nrpe']['packages']          = %w(nrpe nagios-plugins-disk nagios-plugins-load nagios-plugins-procs nagios-plugins-users)

--- a/providers/check.rb
+++ b/providers/check.rb
@@ -33,7 +33,7 @@ action :add do
     group node['nrpe']['group']
     mode '0640'
     content file_contents
-    notifies :reload, "service[#{node['nrpe']['service_name']}]"
+    notifies node['nrpe']['check_action'], "service[#{node['nrpe']['service_name']}]"
   end
   new_resource.updated_by_last_action(f.updated_by_last_action?)
 end
@@ -43,7 +43,7 @@ action :remove do
     Chef::Log.info "Removing #{new_resource.command_name} from #{node['nrpe']['conf_dir']}/nrpe.d/"
     f = file "#{node['nrpe']['conf_dir']}/nrpe.d/#{new_resource.command_name}.cfg" do
       action :delete
-      notifies :reload, "service[#{node['nrpe']['service_name']}]"
+      notifies node['nrpe']['check_action'], "service[#{node['nrpe']['service_name']}]"
     end
     new_resource.updated_by_last_action(f.updated_by_last_action?)
   end

--- a/test/fixtures/cookbooks/chef_nrpe_test/metadata.rb
+++ b/test/fixtures/cookbooks/chef_nrpe_test/metadata.rb
@@ -1,0 +1,4 @@
+name 'chef_nrpe_test'
+version '0.0.1'
+
+depends 'nrpe'

--- a/test/fixtures/cookbooks/chef_nrpe_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/chef_nrpe_test/recipes/default.rb
@@ -1,0 +1,11 @@
+include_recipe 'nrpe'
+
+nrpe_check 'check_root_disk_space' do
+  command_name 'check_root_disk_space'
+  command "#{node['nrpe']['plugin_dir']}/check_disk"
+  warning_condition '5%'
+  critical_condition '1%'
+  parameters '-p /'
+  action :add
+end
+

--- a/test/fixtures/cookbooks/chef_nrpe_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/chef_nrpe_test/recipes/default.rb
@@ -8,4 +8,3 @@ nrpe_check 'check_root_disk_space' do
   parameters '-p /'
   action :add
 end
-


### PR DESCRIPTION
This adds a few features to the nrpe recipe to support CentOS 7.

 1. Add the CentOS 7 bits to Vagrantfile and kitchen.yml
 2. Add test fixture to verify lwrp nrpe_check is tested
 3. Attribute'ize the reload of a nrpe_check to restart on CentOS 7 vs other OSs