### PR TITLE
The attribute ['nrpe']['checks'], which stores all configured checks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.1
 script:

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'berkshelf',  '~> 3.2.0'
 gem 'chefspec',   '~> 4.2.0'
 gem 'foodcritic', '~> 4.0.0'
-gem 'rubocop',    '~> 0.8.0'
+gem 'rubocop',    '~> 0.28.0'
 
 group :integration do
   gem 'test-kitchen',    '~> 1.3.1'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -61,6 +61,9 @@ default['nrpe']['multi_environment_monitoring'] = false
 # this is mostly true except for centos-70
 default['nrpe']['check_action'] = 'reload'
 
+# attribute for storing information about checks on the node
+default['nrpe']['checks'] = []
+
 # platform specific values
 case node['platform_family']
 when 'debian'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -75,3 +75,11 @@ service node['nrpe']['service_name'] do
   action [:start, :enable]
   supports :restart => true, :reload => true, :status => true
 end
+
+# The updating of the list of checks.
+ruby_block 'updating of the list of checks' do
+  block do
+    checks = run_context.resource_collection.select { |r| r.is_a?(Chef::Resource::NrpeCheck) }.map(&:command_name)
+    node.set['nrpe']['checks'] = checks
+  end
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -79,7 +79,7 @@ end
 # The updating of the list of checks.
 ruby_block 'updating of the list of checks' do
   block do
-    checks = run_context.resource_collection.select { |r| r.is_a?(Chef::Resource::NrpeCheck) }.map(&:command_name)
+    checks = run_context.resource_collection.select { |r| r.is_a?(Chef::Resource::NrpeCheck) && r.action == [:add] }.map(&:command_name)
     node.set['nrpe']['checks'] = checks
   end
 end


### PR DESCRIPTION
We use chef searches to add nodes in our monitoring system. But in this case we must configure checks twice: on the node and on the monitoring system, because we can't get list of configured checks from the node.  We would like configure checks in one place, on the node.
The essence of this PR is to add the node attribute which we can use to get all checks on the node and configure same checks on monitoring system automatically.