### PR TITLE
Make yum-epel recipe optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Attributes
 
 ### options for package install
 * `node['nrpe']['package']['options']` - options when installing nrpe via package manager. The default value for this attribute is nil.`
+* `node['nrpe']['install_yum-epel']` - whether to install the EPEL repo or not. The default value is `true`. Set this to `false` if you do not wish to install the EPEL RPM; in this scenario you will need to make the relevant NRPE packages available via another method e.g. local repo.
 
 ### nrpe.conf attributes
 * `node['nrpe']['server_port']` - the port nrpe will listen on, default 5666

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -89,6 +89,7 @@ when 'rhel', 'fedora'
     default['nrpe']['check_action'] = 'restart'
   end
   default['nrpe']['install_method']    = 'package'
+  default['nrpe']['install_yum-epel']  = true
   default['nrpe']['pid_file']          = '/var/run/nrpe.pid'
   default['nrpe']['packages']          = %w(nrpe nagios-plugins-disk nagios-plugins-load nagios-plugins-procs nagios-plugins-users)
   if node['kernel']['machine'] == 'i686'

--- a/recipes/_package_install.rb
+++ b/recipes/_package_install.rb
@@ -23,7 +23,7 @@
 
 # nrpe packages are available in EPEL on rhel / fedora platforms
 # fedora 17 and later don't require epel
-if platform_family?('rhel', 'fedora')
+if platform_family?('rhel', 'fedora') && node['nrpe']['install_yum-epel']
   unless platform?('fedora') && node['platform_version'].to_i > 16
     include_recipe 'yum-epel'
   end


### PR DESCRIPTION
Hi,

Some organisations will have an local copy of the EPEL repo or may use a custom repo with only packages they require. In this case we can provide the option below to skip the `include_recipe 'yum-epel'` based on user preference. Default behaviour remains the same.

Regards,

Peter