### PR TITLE
Resolve NRPE svc startup delay error occuring under systemd on centos 7

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -74,6 +74,8 @@ end
 service node['nrpe']['service_name'] do
   action [:start, :enable]
   supports :restart => true, :reload => true, :status => true
+  retries 3
+  retry_delay 3
 end
 
 # The updating of the list of checks.


### PR DESCRIPTION
For some reason beyond my time-limited understanding the NRPE service is intermittently delayed during startup on Centos 7. The converge eventually times out for the service resource. Subsequent runs usually prove successful.