### PR TITLE
Allow to install desired version of NRPE and reelated packages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file is used to list changes made in each version of nrpe
 
+# UNRELEASED
+* Added default['nrpe']['checks'] to store all checks as a node attribute
+* Removed Ruby 1.9.3 and added Ruby 2.2.0 to Travis
+* Make the yum-epel recipe optional with default['nrpe']['install_yum-epel']
+
 # 1.4.10
 * Add support for CentOS / RHEL
 * Update the LWRP to use the default action functionality introduced in Chef 0.10.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This file is used to list changes made in each version of nrpe
 
-# UNRELEASED
+# 1.4.12 
 * Added default['nrpe']['checks'] to store all checks as a node attribute
 * Removed Ruby 1.9.3 and added Ruby 2.2.0 to Travis
 * Make the yum-epel recipe optional with default['nrpe']['install_yum-epel']

--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -6,7 +6,7 @@ do not update the CHANGELOG.md. Not all changes to the cookbook may
 be merged and released in the same versions. I will handle the version 
 updates during the release process.
 
-If you're change adds new attributes, data bags, or other features
+If your change adds new attributes, data bags, or other features
 please document how to use the change in the cookbook's README.md file.
 Otherwise no one will know how to use your work.
 

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@ APPENDIX: How to apply the Apache License to your work.
    same "printed page" as the copyright notice for easier
    identification within third-party archives.
 
-Copyright [yyyy] [name of copyright owner]
+Copyright 2014 - 2015 Tim Smith
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -71,17 +71,17 @@ when 'debian'
   default['nrpe']['pid_file']          = '/var/run/nagios/nrpe.pid'
   default['nrpe']['home']              = '/usr/lib/nagios'
   default['nrpe']['packages']          = {
-    "nagios-nrpe-server" => {
-      "version" => nil
+    'nagios-nrpe-server' => {
+      'version' => nil
     },
-    "nagios-plugins" => {
-      "version" => nil
+    'nagios-plugins' => {
+      'version' => nil
     },
-    "nagios-plugins-basic" => {
-      "version" => nil
+    'nagios-plugins-basic' => {
+      'version' => nil
     },
-    "nagios-plugins-standard" => {
-      "version" => nil
+    'nagios-plugins-standard' => {
+      'version' => nil
     }
   }
   default['nrpe']['plugin_dir']        = '/usr/lib/nagios/plugins'
@@ -105,20 +105,20 @@ when 'rhel', 'fedora'
   default['nrpe']['install_yum-epel']  = true
   default['nrpe']['pid_file']          = '/var/run/nrpe.pid'
   default['nrpe']['packages']          = {
-    "nrpe" => {
-      "version" => nil
+    'nrpe' => {
+      'version' => nil
     },
-    "nagios-plugins-disk" => {
-      "version" => nil
+    'nagios-plugins-disk' => {
+      'version' => nil
     },
-    "nagios-plugins-load" => {
-      "version" => nil
+    'nagios-plugins-load' => {
+      'version' => nil
     },
-    "nagios-plugins-procs" => {
-      "version" => nil
+    'nagios-plugins-procs' => {
+      'version' => nil
     },
-    "nagios-plugins-users" => {
-      "version" => nil
+    'nagios-plugins-users' => {
+      'version' => nil
     }
   }
   if node['kernel']['machine'] == 'i686'
@@ -136,8 +136,8 @@ when 'freebsd'
   default['nrpe']['install_method']    = 'package'
   default['nrpe']['pid_file']          = '/var/run/nrpe2/nrpe2.pid'
   default['nrpe']['packages']          = {
-    "nrpe" => {
-      "version" => nil
+    'nrpe' => {
+      'version' => nil
     }
   }
   default['nrpe']['log_facility']      = 'daemon'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -70,7 +70,20 @@ when 'debian'
   default['nrpe']['install_method']    = 'package'
   default['nrpe']['pid_file']          = '/var/run/nagios/nrpe.pid'
   default['nrpe']['home']              = '/usr/lib/nagios'
-  default['nrpe']['packages']          = %w(nagios-nrpe-server nagios-plugins nagios-plugins-basic nagios-plugins-standard)
+  default['nrpe']['packages']          = {
+    "nagios-nrpe-server" => {
+      "version" => nil
+    },
+    "nagios-plugins" => {
+      "version" => nil
+    },
+    "nagios-plugins-basic" => {
+      "version" => nil
+    },
+    "nagios-plugins-standard" => {
+      "version" => nil
+    }
+  }
   default['nrpe']['plugin_dir']        = '/usr/lib/nagios/plugins'
   default['nrpe']['conf_dir']          = '/etc/nagios'
   if node['kernel']['machine'] == 'i686'
@@ -91,7 +104,23 @@ when 'rhel', 'fedora'
   default['nrpe']['install_method']    = 'package'
   default['nrpe']['install_yum-epel']  = true
   default['nrpe']['pid_file']          = '/var/run/nrpe.pid'
-  default['nrpe']['packages']          = %w(nrpe nagios-plugins-disk nagios-plugins-load nagios-plugins-procs nagios-plugins-users)
+  default['nrpe']['packages']          = {
+    "nrpe" => {
+      "version" => nil
+    },
+    "nagios-plugins-disk" => {
+      "version" => nil
+    },
+    "nagios-plugins-load" => {
+      "version" => nil
+    },
+    "nagios-plugins-procs" => {
+      "version" => nil
+    },
+    "nagios-plugins-users" => {
+      "version" => nil
+    }
+  }
   if node['kernel']['machine'] == 'i686'
     default['nrpe']['home']            = '/usr/lib/nagios'
     default['nrpe']['ssl_lib_dir']     = '/usr/lib'
@@ -106,7 +135,11 @@ when 'rhel', 'fedora'
 when 'freebsd'
   default['nrpe']['install_method']    = 'package'
   default['nrpe']['pid_file']          = '/var/run/nrpe2/nrpe2.pid'
-  default['nrpe']['packages']          = %w(nrpe)
+  default['nrpe']['packages']          = {
+    "nrpe" => {
+      "version" => nil
+    }
+  }
   default['nrpe']['log_facility']      = 'daemon'
   default['nrpe']['service_name']      = 'nrpe2'
   default['nrpe']['conf_dir']          = '/usr/local/etc'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'tsmith84@gmail.com'
 license           'Apache 2.0'
 description       'Installs and configures Nagios NRPE client'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '1.4.12'
+version           '1.4.13'
 
 recipe 'default', 'Installs and configures a nrpe client'
 %w(build-essential yum-epel).each do |cb|

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'tsmith84@gmail.com'
 license           'Apache 2.0'
 description       'Installs and configures Nagios NRPE client'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '1.4.11'
+version           '1.4.12'
 
 recipe 'default', 'Installs and configures a nrpe client'
 %w(build-essential yum-epel).each do |cb|

--- a/recipes/_package_install.rb
+++ b/recipes/_package_install.rb
@@ -37,17 +37,17 @@ end
 #
 # By default followings are defined and can be adjusted for your tate in your wrapper cookbook
 #   default['nrpe']['packages'] = {
-#     "nagios-nrpe-server"      => {"version" => nil},
-#     "nagios-plugins"          => {"version" => nil},
-#     "nagios-plugins-basic"    => {"version" => nil},
-#     "nagios-plugins-standard" => {"version" => nil}
+#     'nagios-nrpe-server'      => {'version' => nil},
+#     'nagios-plugins'          => {'version' => nil},
+#     'nagios-plugins-basic'    => {'version' => nil},
+#     'nagios-plugins-standard' => {'version' => nil}
 #   }
 # These version information can be overriden in your environment specific attributes so you can intall any version you prefer
 #
 
-node['nrpe']['packages'].each do |pkg,pkg_details|
+node['nrpe']['packages'].each do |pkg, pkg_details|
   package pkg do
-    version pkg_details["version"] unless pkg_details["version"].nil?
+    version pkg_details['version'] unless pkg_details['version'].nil?
     options node['nrpe']['package']['options'] unless node['nrpe']['package']['options'].nil?
   end
 end

--- a/recipes/_package_install.rb
+++ b/recipes/_package_install.rb
@@ -30,8 +30,24 @@ if platform_family?('rhel', 'fedora') && node['nrpe']['install_yum-epel']
 end
 
 # install the nrpe packages specified in the ['nrpe']['packages'] attribute
-node['nrpe']['packages'].each do |pkg|
+#
+# It is defined as Hash.
+#
+# In the hash, by default versions for each packages is nil. So it will install the latest one available in repositories.
+#
+# By default followings are defined and can be adjusted for your tate in your wrapper cookbook
+#   default['nrpe']['packages'] = {
+#     "nagios-nrpe-server"      => {"version" => nil},
+#     "nagios-plugins"          => {"version" => nil},
+#     "nagios-plugins-basic"    => {"version" => nil},
+#     "nagios-plugins-standard" => {"version" => nil}
+#   }
+# These version information can be overriden in your environment specific attributes so you can intall any version you prefer
+#
+
+node['nrpe']['packages'].each do |pkg,pkg_details|
   package pkg do
+    version pkg_details["version"] unless pkg_details["version"].nil?
     options node['nrpe']['package']['options'] unless node['nrpe']['package']['options'].nil?
   end
 end


### PR DESCRIPTION
- By default latest version found in repositories will be installed.
- Node or recipes in the runlist can override the attribute for a specific version