### PR TITLE
Ability to install desired version of NRPE packages instead of latest one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 This file is used to list changes made in each version of nrpe
 
+## 1.5.0
+* Added ability to define node['nrpe']['packages'] as a Hash to add version information as sample below. 
+  In your environment specific cookbook, this version infomation for each individual package can be overriden 
+  for required versions (instead of latest one). If it is nil it will install latest one from repositories.
+
+  Sample:
+  default['nrpe']['packages'] = {
+    'nagios-nrpe-server'      => {'version' => nil},
+    'nagios-plugins'          => {'version' => nil},
+    'nagios-plugins-basic'    => {'version' => nil},
+    'nagios-plugins-standard' => {'version' => nil}
+  }
+
+  For backward compatibiility, it will also install packages if it is defined as an array in your env specific cookbook.
+
 # 1.4.12 
 * Added default['nrpe']['checks'] to store all checks as a node attribute
 * Removed Ruby 1.9.3 and added Ruby 2.2.0 to Travis

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -70,7 +70,20 @@ when 'debian'
   default['nrpe']['install_method']    = 'package'
   default['nrpe']['pid_file']          = '/var/run/nagios/nrpe.pid'
   default['nrpe']['home']              = '/usr/lib/nagios'
-  default['nrpe']['packages']          = %w(nagios-nrpe-server nagios-plugins nagios-plugins-basic nagios-plugins-standard)
+  default['nrpe']['packages']          = {
+    'nagios-nrpe-server' => {
+      'version' => nil
+    },
+    'nagios-plugins' => {
+      'version' => nil
+    },
+    'nagios-plugins-basic' => {
+      'version' => nil
+    },
+    'nagios-plugins-standard' => {
+      'version' => nil
+    }
+  }
   default['nrpe']['plugin_dir']        = '/usr/lib/nagios/plugins'
   default['nrpe']['conf_dir']          = '/etc/nagios'
   if node['kernel']['machine'] == 'i686'
@@ -91,7 +104,23 @@ when 'rhel', 'fedora'
   default['nrpe']['install_method']    = 'package'
   default['nrpe']['install_yum-epel']  = true
   default['nrpe']['pid_file']          = '/var/run/nrpe.pid'
-  default['nrpe']['packages']          = %w(nrpe nagios-plugins-disk nagios-plugins-load nagios-plugins-procs nagios-plugins-users)
+  default['nrpe']['packages']          = {
+    'nrpe' => {
+      'version' => nil
+    },
+    'nagios-plugins-disk' => {
+      'version' => nil
+    },
+    'nagios-plugins-load' => {
+      'version' => nil
+    },
+    'nagios-plugins-procs' => {
+      'version' => nil
+    },
+    'nagios-plugins-users' => {
+      'version' => nil
+    }
+  }
   if node['kernel']['machine'] == 'i686'
     default['nrpe']['home']            = '/usr/lib/nagios'
     default['nrpe']['ssl_lib_dir']     = '/usr/lib'
@@ -106,7 +135,11 @@ when 'rhel', 'fedora'
 when 'freebsd'
   default['nrpe']['install_method']    = 'package'
   default['nrpe']['pid_file']          = '/var/run/nrpe2/nrpe2.pid'
-  default['nrpe']['packages']          = %w(nrpe)
+  default['nrpe']['packages']          = {
+    'nrpe' => {
+      'version' => nil
+    }
+  }
   default['nrpe']['log_facility']      = 'daemon'
   default['nrpe']['service_name']      = 'nrpe2'
   default['nrpe']['conf_dir']          = '/usr/local/etc'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'tsmith84@gmail.com'
 license           'Apache 2.0'
 description       'Installs and configures Nagios NRPE client'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '1.4.14'
+version           '1.5.0'
 
 recipe 'default', 'Installs and configures a nrpe client'
 %w(build-essential yum-epel).each do |cb|

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'tsmith84@gmail.com'
 license           'Apache 2.0'
 description       'Installs and configures Nagios NRPE client'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '1.4.13'
+version           '1.4.13001'
 
 recipe 'default', 'Installs and configures a nrpe client'
 %w(build-essential yum-epel).each do |cb|

--- a/recipes/_package_install.rb
+++ b/recipes/_package_install.rb
@@ -30,8 +30,24 @@ if platform_family?('rhel', 'fedora') && node['nrpe']['install_yum-epel']
 end
 
 # install the nrpe packages specified in the ['nrpe']['packages'] attribute
-node['nrpe']['packages'].each do |pkg|
+#
+# It is defined as Hash.
+#
+# In the hash, by default versions for each packages is nil. So it will install the latest one available in repositories.
+#
+# By default followings are defined and can be adjusted for your tate in your wrapper cookbook
+#   default['nrpe']['packages'] = {
+#     'nagios-nrpe-server'      => {'version' => nil},
+#     'nagios-plugins'          => {'version' => nil},
+#     'nagios-plugins-basic'    => {'version' => nil},
+#     'nagios-plugins-standard' => {'version' => nil}
+#   }
+# These version information can be overriden in your environment specific attributes so you can intall any version you prefer
+#
+
+node['nrpe']['packages'].each do |pkg, pkg_details|
   package pkg do
+    version pkg_details['version'] unless pkg_details['version'].nil?
     options node['nrpe']['package']['options'] unless node['nrpe']['package']['options'].nil?
   end
 end

--- a/recipes/_package_install.rb
+++ b/recipes/_package_install.rb
@@ -31,9 +31,9 @@ end
 
 # install the nrpe packages specified in the ['nrpe']['packages'] attribute
 #
-# It is defined as Hash.
+# For backward compatibility it can be defined as an array or as a Hash.
 #
-# In the hash, by default versions for each packages is nil. So it will install the latest one available in repositories.
+# If it is defined as a hash, by default versions for each packages is nil. So it will install the latest one available in repositories.
 #
 # By default followings are defined and can be adjusted for your tate in your wrapper cookbook
 #   default['nrpe']['packages'] = {
@@ -44,10 +44,19 @@ end
 #   }
 # These version information can be overriden in your environment specific attributes so you can intall any version you prefer
 #
+# In case of defining as an array, it is as usual. It will install latest version found in repositories
 
-node['nrpe']['packages'].each do |pkg, pkg_details|
-  package pkg do
-    version pkg_details['version'] unless pkg_details['version'].nil?
-    options node['nrpe']['package']['options'] unless node['nrpe']['package']['options'].nil?
+if node['nrpe']['packages'].is_a?(Array)
+  node['nrpe']['packages'].each do |pkg|
+    package pkg do
+      options node['nrpe']['package']['options'] unless node['nrpe']['package']['options'].nil?
+    end
+  end
+else
+  node['nrpe']['packages'].each do |pkg, pkg_details|
+    package pkg do
+      version pkg_details['version'] unless pkg_details['version'].nil?
+      options node['nrpe']['package']['options'] unless node['nrpe']['package']['options'].nil?
+    end
   end
 end


### PR DESCRIPTION
['nrpe']['packages'] is now a Hash. Each package has a version attribute
which is nil by default

  default['nrpe']['packages'] = {
    'nagios-nrpe-server'      => {'version' => nil},
    'nagios-plugins'          => {'version' => nil},
    'nagios-plugins-basic'    => {'version' => nil},
    'nagios-plugins-standard' => {'version' => nil}
  }

In your wrapper / role you can define version for any / all of the
packages as example below:

  default!['nrpe']['packages']['nrpe']['version'] = "2.15-2.el#{node['platform_version'][0]}"

Default behavious will be the same as before. If version is nil, latest
version found in repositories will be installed otherwise requested version will be installed.