### PR TITLE
increase security by owning files by root

### DIFF
--- a/providers/check.rb
+++ b/providers/check.rb
@@ -29,7 +29,7 @@ action :add do
   file_contents += " -c #{new_resource.critical_condition}" unless new_resource.critical_condition.nil?
   file_contents += " #{new_resource.parameters}" unless new_resource.parameters.nil?
   f = file "#{node['nrpe']['conf_dir']}/nrpe.d/#{new_resource.command_name}.cfg" do
-    owner node['nrpe']['user']
+    owner 'root'
     group node['nrpe']['group']
     mode '0640'
     content file_contents

--- a/recipes/_source_nrpe.rb
+++ b/recipes/_source_nrpe.rb
@@ -29,15 +29,15 @@ end
 
 template "/etc/init.d/#{node['nrpe']['service_name']}" do
   source 'nagios-nrpe-server.erb'
-  owner node['nrpe']['user']
-  group node['nrpe']['group']
-  mode  '0755'
+  owner 'root'
+  group 'root'
+  mode  '0754'
 end
 
 directory node['nrpe']['conf_dir'] do
-  owner node['nrpe']['user']
+  owner 'root'
   group node['nrpe']['group']
-  mode  '0755'
+  mode  '0750'
 end
 
 bash 'compile-nagios-nrpe' do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -54,16 +54,16 @@ mon_host.concat node['nrpe']['allowed_hosts'] if node['nrpe']['allowed_hosts']
 include_dir = "#{node['nrpe']['conf_dir']}/nrpe.d"
 
 directory include_dir do
-  owner node['nrpe']['user']
+  owner 'root'
   group node['nrpe']['group']
-  mode '0755'
+  mode '0750'
 end
 
 template "#{node['nrpe']['conf_dir']}/nrpe.cfg" do
   source 'nrpe.cfg.erb'
-  owner node['nrpe']['user']
+  owner 'root'
   group node['nrpe']['group']
-  mode '0644'
+  mode '0640'
   variables(
     :mon_host => mon_host.uniq.sort,
     :nrpe_directory => include_dir


### PR DESCRIPTION
...so that nagios user can not modify them

now nagios user can only read the files, but not modify. also prevent others to read the files.

especially important is nagios owned `/etc/init.d/nrpe` init-script: if nagios user can modify it, it has to wait for sysadmin (or machine reboot) to execute the script to gain root privileges to the system.

`node['nrpe']['user']` is still used, defining what uid will be used to startup nrpe daemon