### PR TITLE
Add default rhel7 user/group logic

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,8 +29,13 @@
 default['nrpe']['package']['options'] = nil
 
 # nrpe daemon user/group
-default['nrpe']['user']  = 'nagios'
-default['nrpe']['group'] = 'nagios'
+if node['platform_version'].to_i == 7
+  default['nrpe']['user']  = 'nrpe'
+  default['nrpe']['group'] = 'nrpe'
+else 
+  default['nrpe']['user']  = 'nagios'
+  default['nrpe']['group'] = 'nagios'
+end
 
 # config file options
 default['nrpe']['allow_bash_command_substitution'] = nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,7 +29,7 @@
 default['nrpe']['package']['options'] = nil
 
 # nrpe daemon user/group
-if node['platform_version'].to_i == 7
+if node['platform_family'] == 'rhel' && node['platform_version'].to_i == 7
   default['nrpe']['user']  = 'nrpe'
   default['nrpe']['group'] = 'nrpe'
 else 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,7 +32,7 @@ default['nrpe']['package']['options'] = nil
 if node['platform_family'] == 'rhel' && node['platform_version'].to_i == 7
   default['nrpe']['user']  = 'nrpe'
   default['nrpe']['group'] = 'nrpe'
-else 
+else
   default['nrpe']['user']  = 'nagios'
   default['nrpe']['group'] = 'nagios'
 end


### PR DESCRIPTION
Need logic so RHEL7 uses "nrpe" as user/group by default instead of "nagios". Default "nagios" user/group doesn't seem to work right with the nrpe_check LWRP and causes permission errors when trying to run these checks.